### PR TITLE
SOURCE_ACCOUNTS no longer used

### DIFF
--- a/local_settings_example.py
+++ b/local_settings_example.py
@@ -18,7 +18,6 @@ CLIENT_CRED_FILENAME = '' # the MASTODON client secret file you created for this
 USER_ACCESS_FILENAME = '' # The MASTODON user credential file you created at installation.
 
 # Sources (Twitter, Mastodon, local text file or a web page)
-SOURCE_ACCOUNTS = [""]  # A list of comma-separated, quote-enclosed Twitter handles of account that you'll generate tweets based on. It should look like ["account1", "account2"]. If you want just one account, no comma needed.
 TWITTER_SOURCE_ACCOUNTS = [""]  # A list of comma-separated, quote-enclosed Twitter handles of account that you'll generate tweets based on. It should look like ["account1", "account2"]. If you want just one account, no comma needed.
 MASTODON_SOURCE_ACCOUNTS = [""] # A list, e.g. ["@user@instance.tld"]
 SOURCE_EXCLUDE = r'^$'  # Source tweets that match this regexp will not be added to the Markov chain. You might want to filter out inappropriate words for example.


### PR DESCRIPTION
SOURCE_ACCOUNTS seems to be depracated in favour of TWITTER_SOURCE_ACCOUNTS. It should be removed to be less confusing.